### PR TITLE
Unnest `link_to` from `p` tag to prevent weird styles

### DIFF
--- a/bootstrap.md
+++ b/bootstrap.md
@@ -358,8 +358,7 @@ The structure of this view will match the layout we defined for book views, with
     %h1 Looking for a new Book?
     %h3 Ready to get reading?
     %br
-    %p
-      = link_to 'Get Book Info', books_path, class: "btn btn-primary btn-lg"
+    = link_to 'Get Book Info', books_path, class: "btn btn-primary btn-lg"
 .container
   .row
     .col-lg-6


### PR DESCRIPTION
When this code had `button_to` nested inside the `p` tag the  generated HTML looked like this.
```
<p>
  <form>
    <input />
  </form>
</p>
```

But browsers don't let you nest a `<form>` tag inside of a `<p>` tag, it's not allowed. <p> tags can only have "phrasing content" nested inside of them. That means that when this HTML structure was actually rendered in the browser, browsers were turning it into this structure. This was actually ok because the styles defined that `<p>` tags have a black background so if the browser didn't do that you wouldn't even be able to see the link.
```
<p></p>
<form>
  <input />
</form>
```

Now that I have changed it to use `link_to` rather than `button_to` the `<a>` tag does actually get nested inside the <p> tag and it's not visible from the black background. This PR fixes that up.